### PR TITLE
Suppress the JDK 25 "identity" warning

### DIFF
--- a/nonnull-interned-demo/daikon/src/utilMDE/Intern.java
+++ b/nonnull-interned-demo/daikon/src/utilMDE/Intern.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.interning.qual.Interned;
 /**
  * Utilities for interning objects.
  **/
+@SuppressWarnings("identity") // JDK 25+ does not consider Interned
 public final class Intern {
   private Intern() { throw new Error("do not instantiate"); }
 


### PR DESCRIPTION
Recently, the JDK 25 compiler in GitHub Actions was updated, leading to new failures in the EISOP misc tests on JDK 25:

````
> /home/runner/work/checker-framework/checker-framework.demos/nonnull-interned-demo/daikon/src/utilMDE/Intern.java:436: warning: [identity] use of a value-based class with an operation that expects reliable identity
  >       internedDoubles.put(result, new WeakReference<@Interned Double>(result));
  >                                                    ^
  > /home/runner/work/checker-framework/checker-framework.demos/nonnull-interned-demo/daikon/src/utilMDE/Intern.java:436: warning: [identity] use of a value-based class with an operation that expects reliable identity
  >       internedDoubles.put(result, new WeakReference<@Interned Double>(result));
  >                                                                       ^
  > Note: Some input files use or override a deprecated API.
  > Note: Recompile with -Xlint:deprecation for details.
  > Note: Some input files use unchecked or unsafe operations.
  > Note: Recompile with -Xlint:unchecked for details.
  16a69
  > 15 warnings 
````

It seems okay to suppress these warnings.